### PR TITLE
Some minor changes

### DIFF
--- a/Workspace.spec
+++ b/Workspace.spec
@@ -64,7 +64,7 @@ typedef tuple<ObjectName,ObjectType,FullObjectPath,Timestamp creation_time,Objec
 	Parameters:
 	list<tuple<FullObjectPath,ObjectType,UserMetadata,ObjectData>> objects - data on objects being create; use type "Directory" to create a directory; data does not need to be specified if creating a directory or upload node
 	WorkspacePerm permission - this will be the default permission specified for any top level directories being created (optional; default = "n")
-	bool uploadNodes - set this boolean to "1" if we are creating upload nodes instead of objects or directories (optional; default = "0")
+	bool createUploadNodes - set this boolean to "1" if we are creating upload nodes instead of objects or directories (optional; default = "0")
 	bool overwrite - set this boolean to "1" if we should overwrite existing objects; directories cannot be overwritten (optional; default = "0")
 
 */

--- a/lib/Bio/P3/Workspace/WorkspaceImpl.pm
+++ b/lib/Bio/P3/Workspace/WorkspaceImpl.pm
@@ -3,7 +3,7 @@ use strict;
 use Bio::KBase::Exceptions;
 # Use Semantic Versioning (2.0.0-rc.1)
 # http://semver.org 
-our $VERSION = "0.2.0";
+our $VERSION = "0.1.0";
 
 =head1 NAME
 
@@ -1012,7 +1012,7 @@ create_params is a reference to a hash where the following keys are defined:
 	3: an ObjectData
 
 	permission has a value which is a WorkspacePerm
-	uploadNodes has a value which is a bool
+	createUploadNodes has a value which is a bool
 	downloadLinks has a value which is a bool
 	overwrite has a value which is a bool
 FullObjectPath is a string
@@ -1058,7 +1058,7 @@ create_params is a reference to a hash where the following keys are defined:
 	3: an ObjectData
 
 	permission has a value which is a WorkspacePerm
-	uploadNodes has a value which is a bool
+	createUploadNodes has a value which is a bool
 	downloadLinks has a value which is a bool
 	overwrite has a value which is a bool
 FullObjectPath is a string
@@ -1420,6 +1420,8 @@ sub ls
     my $ctx = $Bio::P3::Workspace::Service::CallContext;
     my($output);
     #BEGIN ls
+
+    $output = {};
     $input = $self->_validateargs($input,["paths"],{
     	excludeDirectories => 0,
 		excludeObjects => 0,
@@ -2501,7 +2503,7 @@ objects has a value which is a reference to a list where each element is a refer
 3: an ObjectData
 
 permission has a value which is a WorkspacePerm
-uploadNodes has a value which is a bool
+createUploadNodes has a value which is a bool
 downloadLinks has a value which is a bool
 overwrite has a value which is a bool
 
@@ -2519,7 +2521,7 @@ objects has a value which is a reference to a list where each element is a refer
 3: an ObjectData
 
 permission has a value which is a WorkspacePerm
-uploadNodes has a value which is a bool
+createUploadNodes has a value which is a bool
 downloadLinks has a value which is a bool
 overwrite has a value which is a bool
 

--- a/scripts/ws-cat.pl
+++ b/scripts/ws-cat.pl
@@ -1,0 +1,76 @@
+
+use strict;
+use Getopt::Long::Descriptive;
+use Data::Dumper;
+use Bio::P3::Workspace::WorkspaceClient;
+use Bio::P3::Workspace::ScriptHelpers;
+use Text::Table;
+use Bio::KBase::AuthToken;
+use LWP::UserAgent;
+
+=head1 NAME
+
+ws-cat
+
+=head1 SYNOPSIS
+
+ws-cat path [path...]
+
+=head1 DESCRIPTION
+
+Dump the contents of the given path to stdout. If the --shock flag is given,
+retrieve the contents of shock-based files.
+
+=head1 COMMAND-LINE OPTIONS
+
+ws-cat.pl [-h] [long options...] path [path...]
+	--url       Service URL
+	--shock     Retrieve data stored in Shock
+	-h --help   Show this usage message
+=cut
+
+my @options = (["url=s", 'Service URL'],
+	       ["shock", "Retrieve data stored in Shock"],
+	       ["help|h", "Show this usage message"]);
+
+my($opt, $usage) = describe_options("%c %o path [path...]",
+				    @options);
+
+print($usage->text), exit if $opt->help;
+
+my $ws = Bio::P3::Workspace::ScriptHelpers::wsClient($opt->url);
+
+my @paths = @ARGV;
+
+my $res = $ws->get({ objects => \@paths });
+
+my $token;
+my $cb;
+my $ua;
+
+if ($opt->shock)
+{
+    $token = Bio::KBase::AuthToken->new();
+
+    $cb = sub {
+	my($data) = @_;
+	print $data;
+    };
+    $ua = LWP::UserAgent->new();
+}
+
+for my $ent (@$res)
+{
+    my($meta, $data) = @$ent;
+
+    if ((my $url = $meta->[11]) && $opt->shock)
+    {
+	my $res = $ua->get("$url?download",
+			   Authorization => "OAuth " . $token->token,
+			   ':content_cb' => $cb);
+    }
+    else
+    {
+	print $data;
+    }
+}

--- a/scripts/ws-ls.pl
+++ b/scripts/ws-ls.pl
@@ -51,10 +51,10 @@ for my $p (@paths)
     {
 	my($name, $type, $path, $created, $id, $owner, $size, $user_meta, $auto_meta, $user_perm,
 	   $global_perm, $shockurl) = @$file;
-	push(@$tbl, [$name, $owner, $type, $created, $size, $user_perm, $global_perm]);
+	push(@$tbl, [$name, $owner, $type, $created, $size, $user_perm, $global_perm, $shockurl]);
     }
     my $table = Text::Table->new(
-				 "Name","Owner","Type","Moddate","Size","User perm","Global perm",
+				 "Name","Owner","Type","Moddate","Size","User perm","Global perm", "Shock URL"
 				);
     $table->load(@{$tbl});
     print $table."\n";

--- a/scripts/ws-upload.pl
+++ b/scripts/ws-upload.pl
@@ -1,0 +1,82 @@
+
+use strict;
+use Getopt::Long::Descriptive;
+use Data::Dumper;
+use Bio::P3::Workspace::WorkspaceClient;
+use Bio::P3::Workspace::ScriptHelpers;
+use Text::Table;
+use Bio::KBase::AuthToken;
+use LWP::UserAgent;
+use File::Slurp;
+use HTTP::Request::Common;
+use Cwd 'abs_path';
+
+=head1 NAME
+
+ws-upload
+
+=head1 SYNOPSIS
+
+ws-upload local-file workspace-file
+
+=head1 DESCRIPTION
+
+Upload a single file into the workspace. Place into Shock if the --shock flag is given.
+    
+=head1 COMMAND-LINE OPTIONS
+
+ws-cat.pl [-h] [long options...] path [path...]
+	--url       Service URL
+	--shock     Retrieve data stored in Shock
+	-h --help   Show this usage message
+=cut
+
+my @options = (["url=s", 'Service URL'],
+	       ["shock", "Retrieve data stored in Shock"],
+	       ["overwrite", "Overwrite existing files"],
+	       ["help|h", "Show this usage message"]);
+
+my($opt, $usage) = describe_options("%c %o local-file workspace-file",
+				    @options);
+
+print($usage->text), exit if $opt->help;
+print($usage->text), exit 1 if (@ARGV != 2);
+
+my $local_file = shift;
+my $ws_file = shift;
+
+my $ws = Bio::P3::Workspace::ScriptHelpers::wsClient($opt->url);
+
+-f $local_file or die "Local file $local_file does not exist\n";
+$local_file = abs_path($local_file);
+
+if ($opt->shock)
+{
+    my $token = Bio::KBase::AuthToken->new();
+    my $ua = LWP::UserAgent->new();
+
+    my $res = $ws->create({ objects => [[$ws_file, 'unspecified', { original_file => $local_file } ]],
+				overwrite => ($opt->overwrite ? 1 : 0),
+				createUploadNodes => 1 });
+    if (!ref($res) || @$res == 0)
+    {
+	die "Create failed";
+    }
+    $res = $res->[0];
+    my $shock_url = $res->[11];
+
+    my $req = HTTP::Request::Common::POST($shock_url, 
+					  Authorization => "OAuth " . $token->token,
+					  Content_Type => 'multipart/form-data',
+					  Content => [upload => [$local_file]]);
+    $req->method('PUT');
+    my $sres = $ua->request($req);
+    print Dumper($sres->content);
+}
+else
+{
+    my $res = $ws->create({ objects => [[$ws_file, 'unspecified', { original_file => $local_file },
+					scalar read_file($local_file)]] });
+    print Dumper($res);
+}
+    


### PR DESCRIPTION
This pull req fixes the behavior of ws-ls when passed an empty list, and updates ws-ls to the new API. It also adds ws-cat to dump files from the workspace to stdout. If the ws file is a shock URL and --shock is given on the command line, retrieves the file from shock (using the user's current credentials) and dumps it to stdout.