### PR TITLE
Add WorkspaceClientExt that adds upload/download helpers.

### DIFF
--- a/lib/Bio/P3/Workspace/ScriptHelpers.pm
+++ b/lib/Bio/P3/Workspace/ScriptHelpers.pm
@@ -2,6 +2,7 @@ package Bio::P3::Workspace::ScriptHelpers;
 use strict;
 use warnings;
 use Bio::P3::Workspace::WorkspaceClient;
+use Bio::P3::Workspace::WorkspaceClientExt;
 
 our $defaultWSURL   = "http://p3.theseed.org/services/Workspace";
 
@@ -169,7 +170,7 @@ sub wsClient {
 			return Bio::P3::Workspace::WorkspaceImpl->new();
 		};
 	}
-	return Bio::P3::Workspace::WorkspaceClient->new($url);
+	return Bio::P3::Workspace::WorkspaceClientExt->new($url);
 }
 
 sub token {

--- a/lib/Bio/P3/Workspace/WorkspaceClientExt.pm
+++ b/lib/Bio/P3/Workspace/WorkspaceClientExt.pm
@@ -1,0 +1,106 @@
+package Bio::P3::Workspace::WorkspaceClientExt;
+
+use Data::Dumper;
+use strict;
+use base 'Bio::P3::Workspace::WorkspaceClient';
+use LWP::UserAgent;
+
+sub copy_files_to_handles
+{
+    my($self, $use_shock, $token, $file_handle_pairs) = @_;
+
+    my $ua;
+    if ($use_shock)
+    {
+	$ua = LWP::UserAgent->new();
+	$token = $token->token if ref($token);
+    }
+
+    my %fhmap = map { @$_ } @$file_handle_pairs;
+    my $res = $self->get({ objects => [ map { $_->[0] } @$file_handle_pairs] });
+    
+    for my $ent (@$res)
+    {
+	my($meta, $data) = @$ent;
+
+	bless $meta, 'Bio::P3::Workspace::ObjectMeta';
+	my $fh = $fhmap{$meta->full_path};
+
+	if ($use_shock && $meta->shock_url)
+	{
+	    my $cb = sub {
+		my($data) = @_;
+		print $fh $data;
+	    };
+
+	    my $res = $ua->get($meta->shock_url. "?download",
+			       Authorization => "OAuth " . $token,
+			       ':content_cb' => $cb);
+	    if (!$res->is_success)
+	    {
+		warn "Error retrieving " . $meta->shock_url . ": " . $res->content . "\n";
+	    }
+	}
+	else
+	{
+	    print $fh $data;
+	}
+    }
+}
+
+
+sub save_data_to_file
+{
+    my($self, $data, $metadata, $path, $type, $overwrite, $use_shock, $token) = @_;
+
+    $type ||= 'unspecified';
+
+    if ($use_shock)
+    {
+	$token = $token->token if ref($token);
+	my $ua = LWP::UserAgent->new();
+
+	my $res = $self->create({ objects => [[$path, $type, $metadata ]],
+				overwrite => ($overwrite ? 1 : 0),
+				createUploadNodes => 1 });
+	if (!ref($res) || @$res == 0)
+	{
+	    die "Create failed";
+	}
+	$res = $res->[0];
+	my $shock_url = $res->[11];
+	
+	my $req = HTTP::Request::Common::POST($shock_url, 
+					      Authorization => "OAuth " . $token,
+					      Content_Type => 'multipart/form-data',
+					      Content => [upload => [undef, 'file', Content => $data]]);
+	$req->method('PUT');
+	my $sres = $ua->request($req);
+	print STDERR Dumper($sres->content);
+    }
+    else
+    {
+	my $res = $self->create({ objects => [[$path, $type, $metadata, $data ]],
+				overwrite => ($overwrite ? 1 : 0) });
+	print STDERR Dumper($res);
+    }
+}
+
+
+
+
+package Bio::P3::Workspace::ObjectMeta;
+sub name { return $_[0]->[0] };
+sub type { return $_[0]->[1] };
+sub path { return $_[0]->[2] };
+sub full_path { return join("", @{$_[0]}[2,0]); }
+sub creation_time { return $_[0]->[3] };
+sub id { return $_[0]->[4] };
+sub owner { return $_[0]->[5] };
+sub size { return $_[0]->[6] };
+sub user_metadata { return $_[0]->[7] };
+sub auto_metadata { return $_[0]->[8] };
+sub user_permission { return $_[0]->[9] };
+sub global_permission { return $_[0]->[10] };
+sub shock_url { return $_[0]->[11] };
+1;

--- a/scripts/ws-ls.pl
+++ b/scripts/ws-ls.pl
@@ -22,11 +22,13 @@ List the contents of a workspace directory.
 
 ws-ls path [long options...]
 	--url      URL to use for workspace service
+        --shock    Include Shock URLs
 	--help     print usage message and exit
 
 =cut
 
 my @options = (["url=s", 'Service URL'],
+	       ['shock', 'Include Shock URLs'],
 	       ["help|h", "Show this usage message"]);
 
 my($opt, $usage) = describe_options("%c %o path",
@@ -51,10 +53,10 @@ for my $p (@paths)
     {
 	my($name, $type, $path, $created, $id, $owner, $size, $user_meta, $auto_meta, $user_perm,
 	   $global_perm, $shockurl) = @$file;
-	push(@$tbl, [$name, $owner, $type, $created, $size, $user_perm, $global_perm, $shockurl]);
+	push(@$tbl, [$name, $owner, $type, $created, $size, $user_perm, $global_perm, ($opt->shock ? $shockurl  : ())]);
     }
     my $table = Text::Table->new(
-				 "Name","Owner","Type","Moddate","Size","User perm","Global perm", "Shock URL"
+				 "Name","Owner","Type","Moddate","Size","User perm","Global perm", ($opt->shock ? "Shock URL" : ())
 				);
     $table->load(@{$tbl});
     print $table."\n";

--- a/scripts/ws-upload.pl
+++ b/scripts/ws-upload.pl
@@ -52,6 +52,7 @@ $local_file = abs_path($local_file);
 
 if ($opt->shock)
 {
+    local $HTTP::Request::Common::DYNAMIC_FILE_UPLOAD = 1;
     my $token = Bio::KBase::AuthToken->new();
     my $ua = LWP::UserAgent->new();
 


### PR DESCRIPTION
WorkspaceClientExt is a subclass of WorkspaceClient that adds routines for pulling multiple data files from the WS to specified filehandles, and does the Shock download if necessary & requested, and to push data from memory up to the WS, again using Shock if requested.